### PR TITLE
A few assorted fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ configurations {
 
 dependencies {
     def asm = '9.3'
-    def sim = '1.9.1'
+    def sim = '1.9.2'
     // objectweb asm
     compileOnly "org.ow2.asm:asm:${asm}"
     compileOnly "org.ow2.asm:asm-commons:${asm}"

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,12 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:5.8.2"
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 test {
     useJUnitPlatform()
 }

--- a/src/main/java/me/darknet/resconstruct/ClassHierarchy.java
+++ b/src/main/java/me/darknet/resconstruct/ClassHierarchy.java
@@ -35,6 +35,8 @@ public class ClassHierarchy {
 	}
 
 	public PhantomClass getOrCreate(Type type) {
+		if (type == null)
+			throw new GenerateException("Tried to lookup phantom by type, but passed 'null'");
 		return phantoms.computeIfAbsent(type.getInternalName(), t -> {
 			boolean isCp = InheritanceUtils.isClasspathType(type);
 			return new PhantomClass(type) {

--- a/src/main/java/me/darknet/resconstruct/analysis/StackCopyingSimFrame.java
+++ b/src/main/java/me/darknet/resconstruct/analysis/StackCopyingSimFrame.java
@@ -127,8 +127,12 @@ public class StackCopyingSimFrame extends SimFrame {
 		// using the updated values.
 		super.execute(insn, interpreter);
 		// Update local variable information
+		int wideCount = 0;
 		for (int i = 0; i < frame.local.size(); i++) {
-			AbstractValue value = getLocal(i);
+			// The index in the "locals" of an ASM stack analysis frame must account for wide types.
+			// So we will adjust for it here. We do not need to do so for stack-frames since they
+			// do not account for wide types and their reserved slots.
+			AbstractValue value = getLocal(i + wideCount);
 			// We only care about object/virtual values
 			if (value instanceof VirtualValue) {
 				// Get the type in the stack-frame at the current index.
@@ -152,6 +156,8 @@ public class StackCopyingSimFrame extends SimFrame {
 				// Updating the last initialized frame updates the information that will be returned by the
 				// SimAnalyzer's "analyze(...)" method.
 				lastInitted.setLocal(i, newValue);
+			} else if (value.isWide()) {
+				wideCount++;
 			}
 		}
 	}

--- a/src/main/java/me/darknet/resconstruct/instructions/MethodInstructionSolver.java
+++ b/src/main/java/me/darknet/resconstruct/instructions/MethodInstructionSolver.java
@@ -2,6 +2,7 @@ package me.darknet.resconstruct.instructions;
 
 import me.coley.analysis.SimFrame;
 import me.coley.analysis.value.AbstractValue;
+import me.coley.analysis.value.UninitializedValue;
 import me.darknet.resconstruct.ClassHierarchy;
 import me.darknet.resconstruct.PhantomClass;
 import me.darknet.resconstruct.util.TypeUtils;
@@ -39,8 +40,13 @@ public class MethodInstructionSolver implements InstructionSolver<MethodInsnNode
 	}
 
 	private void inferOwnerType(MethodInsnNode instruction, SimFrame frame, ClassHierarchy hierarchy) {
-		int offset = TypeUtils.getArgumentsSize(instruction.desc) + 1;
+		// ASM's analysis framework does not handle 'wide' values, so we don't need to
+		// consider the width of values. Therefore, just count the number of arguments.
+		int offset = TypeUtils.getArgumentsCount(instruction.desc) + 1;
 		AbstractValue ownerValue = frame.getStack(frame.getStackSize() - offset);
+		if (ownerValue == UninitializedValue.UNINITIALIZED_VALUE) {
+			return;
+		}
 		Type ownerType = Type.getObjectType(instruction.owner);
 		Type stackType = ownerValue.getType();
 		PhantomClass phantomActual = hierarchy.getOrCreate(ownerType);

--- a/src/main/java/me/darknet/resconstruct/instructions/VarInstructionSolver.java
+++ b/src/main/java/me/darknet/resconstruct/instructions/VarInstructionSolver.java
@@ -3,6 +3,7 @@ package me.darknet.resconstruct.instructions;
 import me.coley.analysis.SimFrame;
 import me.coley.analysis.TypeResolver;
 import me.coley.analysis.value.AbstractValue;
+import me.coley.analysis.value.UninitializedValue;
 import me.darknet.resconstruct.ClassHierarchy;
 import me.darknet.resconstruct.PhantomClass;
 import me.darknet.resconstruct.util.TypeUtils;
@@ -29,6 +30,10 @@ public class VarInstructionSolver implements InstructionSolver<VarInsnNode> {
 		SimFrame next = frame.getFlowOutputs().iterator().next();
 		AbstractValue localValue = next.getLocal(insnNode.var);
 		AbstractValue stackValue = frame.getStack(frame.getStackSize() - 1);
+		if (localValue == UninitializedValue.UNINITIALIZED_VALUE) {
+			// Can't infer anything if local value is not initialized.
+			return;
+		}
 		Type stackType = stackValue.getType();
 		Type localType = localValue.getType();
 		PhantomClass phantomActual = hierarchy.getOrCreate(stackType);

--- a/src/main/java/me/darknet/resconstruct/util/TypeUtils.java
+++ b/src/main/java/me/darknet/resconstruct/util/TypeUtils.java
@@ -25,6 +25,17 @@ public class TypeUtils {
 		return size;
 	}
 
+	/**
+	 * @param desc
+	 * 		Method descriptor.
+	 *
+	 * @return Number of arguments.
+	 */
+	public static int getArgumentsCount(String desc) {
+		Type methodType = Type.getMethodType(desc);
+		return methodType.getArgumentTypes().length;
+	}
+
 	public static Type computeBestType(Type currentType, Type frameType, TypeResolver typeResolver) {
 		Type commonType = (currentType.equals(frameType)) ? currentType :
 				typeResolver.common(currentType, frameType);


### PR DESCRIPTION
- IntelliJ JUnit run tasks failing because compiler version is not set _(fixed with toolchains)_
- Misaligned comparison of ASM frame locals and StackMapTable frame locals due to wide type handling differences
- Extracting type info from ASM frame's `int` value in locals